### PR TITLE
Fixed column name inconsistencies

### DIFF
--- a/notebook/1 . EDA STUDENT PERFORMANCE .ipynb
+++ b/notebook/1 . EDA STUDENT PERFORMANCE .ipynb
@@ -1187,11 +1187,11 @@
    "source": [
     "plt.subplots(1,3,figsize=(25,6))\n",
     "plt.subplot(141)\n",
-    "ax =sns.histplot(data=df,x='average',kde=True,hue='parental level of education')\n",
+    "ax =sns.histplot(data=df,x='average',kde=True,hue='parental_level_of_education')\n",
     "plt.subplot(142)\n",
-    "ax =sns.histplot(data=df[df.gender=='male'],x='average',kde=True,hue='parental level of education')\n",
+    "ax =sns.histplot(data=df[df.gender=='male'],x='average',kde=True,hue='parental_level_of_education')\n",
     "plt.subplot(143)\n",
-    "ax =sns.histplot(data=df[df.gender=='female'],x='average',kde=True,hue='parental level of education')\n",
+    "ax =sns.histplot(data=df[df.gender=='female'],x='average',kde=True,hue='parental_level_of_education')\n",
     "plt.show()"
    ]
   },
@@ -1215,11 +1215,11 @@
    "source": [
     "plt.subplots(1,3,figsize=(25,6))\n",
     "plt.subplot(141)\n",
-    "ax =sns.histplot(data=df,x='average',kde=True,hue='race/ethnicity')\n",
+    "ax =sns.histplot(data=df,x='average',kde=True,hue='race_ethnicity')\n",
     "plt.subplot(142)\n",
-    "ax =sns.histplot(data=df[df.gender=='female'],x='average',kde=True,hue='race/ethnicity')\n",
+    "ax =sns.histplot(data=df[df.gender=='female'],x='average',kde=True,hue='race_ethnicity')\n",
     "plt.subplot(143)\n",
-    "ax =sns.histplot(data=df[df.gender=='male'],x='average',kde=True,hue='race/ethnicity')\n",
+    "ax =sns.histplot(data=df[df.gender=='male'],x='average',kde=True,hue='race_ethnicity')\n",
     "plt.show()"
    ]
   },
@@ -1252,13 +1252,13 @@
     "plt.figure(figsize=(18,8))\n",
     "plt.subplot(1, 4, 1)\n",
     "plt.title('MATH SCORES')\n",
-    "sns.violinplot(y='math score',data=df,color='red',linewidth=3)\n",
+    "sns.violinplot(y='math_score',data=df,color='red',linewidth=3)\n",
     "plt.subplot(1, 4, 2)\n",
     "plt.title('READING SCORES')\n",
-    "sns.violinplot(y='reading score',data=df,color='green',linewidth=3)\n",
+    "sns.violinplot(y='reading_score',data=df,color='green',linewidth=3)\n",
     "plt.subplot(1, 4, 3)\n",
     "plt.title('WRITING SCORES')\n",
-    "sns.violinplot(y='writing score',data=df,color='blue',linewidth=3)\n",
+    "sns.violinplot(y='writing_score',data=df,color='blue',linewidth=3)\n",
     "plt.show()"
    ]
   },
@@ -1301,7 +1301,7 @@
     "\n",
     "\n",
     "plt.subplot(1, 5, 2)\n",
-    "size = df['race/ethnicity'].value_counts()\n",
+    "size = df['race_ethnicity'].value_counts()\n",
     "labels = 'Group C', 'Group D','Group B','Group E','Group A'\n",
     "color = ['red', 'green', 'blue', 'cyan','orange']\n",
     "\n",
@@ -1322,7 +1322,7 @@
     "\n",
     "\n",
     "plt.subplot(1, 5, 4)\n",
-    "size = df['test preparation course'].value_counts()\n",
+    "size = df['test_preparation_course'].value_counts()\n",
     "labels = 'None', 'Completed'\n",
     "color = ['red','green']\n",
     "\n",
@@ -1332,7 +1332,7 @@
     "\n",
     "\n",
     "plt.subplot(1, 5, 5)\n",
-    "size = df['parental level of education'].value_counts()\n",
+    "size = df['parental_level_of_education'].value_counts()\n",
     "labels = 'Some College', \"Associate's Degree\",'High School','Some High School',\"Bachelor's Degree\",\"Master's Degree\"\n",
     "color = ['red', 'green', 'blue', 'cyan','orange','grey']\n",
     "\n",
@@ -1396,12 +1396,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cfb8c9b2",
    "metadata": {},
    "source": [
     "#### Insights \n",
-    "- Gender has balanced data with female students are 518 (48%) and male students are 482 (52%) "
+    "- Gender has balanced data with female students are 518 (52%) and male students are 482 (48%) "
    ]
   },
   {
@@ -1419,7 +1420,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gender_group = df.groupby('gender').mean()\n",
+    "score_columns = ['average', 'math_score']\n",
+    "gender_group = df.groupby('gender')[score_columns].mean()\n",
     "gender_group"
    ]
   },
@@ -1435,8 +1437,8 @@
     "X = ['Total Average','Math Average']\n",
     "\n",
     "\n",
-    "female_scores = [gender_group['average'][0], gender_group['math score'][0]]\n",
-    "male_scores = [gender_group['average'][1], gender_group['math score'][1]]\n",
+    "female_scores = [gender_group['average'][0], gender_group['math_score'][0]]\n",
+    "male_scores = [gender_group['average'][1], gender_group['math_score'][1]]\n",
     "\n",
     "X_axis = np.arange(len(X))\n",
     "  \n",
@@ -1486,11 +1488,11 @@
    "outputs": [],
    "source": [
     "f,ax=plt.subplots(1,2,figsize=(20,10))\n",
-    "sns.countplot(x=df['race/ethnicity'],data=df,palette = 'bright',ax=ax[0],saturation=0.95)\n",
+    "sns.countplot(x=df['race_ethnicity'],data=df,palette = 'bright',ax=ax[0],saturation=0.95)\n",
     "for container in ax[0].containers:\n",
     "    ax[0].bar_label(container,color='black',size=20)\n",
     "    \n",
-    "plt.pie(x = df['race/ethnicity'].value_counts(),labels=df['race/ethnicity'].value_counts().index,explode=[0.1,0,0,0,0],autopct='%1.1f%%',shadow=True)\n",
+    "plt.pie(x = df['race_ethnicity'].value_counts(),labels=df['race_ethnicity'].value_counts().index,explode=[0.1,0,0,0,0],autopct='%1.1f%%',shadow=True)\n",
     "plt.show()   "
    ]
   },
@@ -1519,21 +1521,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Group_data2=df.groupby('race/ethnicity')\n",
+    "Group_data2=df.groupby('race_ethnicity')\n",
     "f,ax=plt.subplots(1,3,figsize=(20,8))\n",
-    "sns.barplot(x=Group_data2['math score'].mean().index,y=Group_data2['math score'].mean().values,palette = 'mako',ax=ax[0])\n",
+    "sns.barplot(x=Group_data2['math_score'].mean().index,y=Group_data2['math_score'].mean().values,palette = 'mako',ax=ax[0])\n",
     "ax[0].set_title('Math score',color='#005ce6',size=20)\n",
     "\n",
     "for container in ax[0].containers:\n",
     "    ax[0].bar_label(container,color='black',size=15)\n",
     "\n",
-    "sns.barplot(x=Group_data2['reading score'].mean().index,y=Group_data2['reading score'].mean().values,palette = 'flare',ax=ax[1])\n",
+    "sns.barplot(x=Group_data2['reading_score'].mean().index,y=Group_data2['reading_score'].mean().values,palette = 'flare',ax=ax[1])\n",
     "ax[1].set_title('Reading score',color='#005ce6',size=20)\n",
     "\n",
     "for container in ax[1].containers:\n",
     "    ax[1].bar_label(container,color='black',size=15)\n",
     "\n",
-    "sns.barplot(x=Group_data2['writing score'].mean().index,y=Group_data2['writing score'].mean().values,palette = 'coolwarm',ax=ax[2])\n",
+    "sns.barplot(x=Group_data2['writing_score'].mean().index,y=Group_data2['writing_score'].mean().values,palette = 'coolwarm',ax=ax[2])\n",
     "ax[2].set_title('Writing score',color='#005ce6',size=20)\n",
     "\n",
     "for container in ax[2].containers:\n",
@@ -1578,7 +1580,7 @@
    "source": [
     "plt.rcParams['figure.figsize'] = (15, 9)\n",
     "plt.style.use('fivethirtyeight')\n",
-    "sns.countplot(df['parental level of education'], palette = 'Blues')\n",
+    "sns.countplot(x=df['parental_level_of_education'], palette='Blues')\n",
     "plt.title('Comparison of Parental Education', fontweight = 30, fontsize = 20)\n",
     "plt.xlabel('Degree')\n",
     "plt.ylabel('count')\n",
@@ -1609,7 +1611,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.groupby('parental level of education').agg('mean').plot(kind='barh',figsize=(10,10))\n",
+    "df.groupby('parental_level_of_education')['average'].agg('mean').plot(kind='barh',figsize=(10,10))\n",
     "plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)\n",
     "plt.show()"
    ]
@@ -1650,7 +1652,7 @@
    "source": [
     "plt.rcParams['figure.figsize'] = (15, 9)\n",
     "plt.style.use('seaborn-talk')\n",
-    "sns.countplot(df['lunch'], palette = 'PuBu')\n",
+    "sns.countplot(x = df['lunch'], palette = 'PuBu')\n",
     "plt.title('Comparison of different types of lunch', fontweight = 30, fontsize = 20)\n",
     "plt.xlabel('types of lunch')\n",
     "plt.ylabel('count')\n",
@@ -1682,12 +1684,13 @@
    "outputs": [],
    "source": [
     "f,ax=plt.subplots(1,2,figsize=(20,8))\n",
-    "sns.countplot(x=df['parental level of education'],data=df,palette = 'bright',hue='test preparation course',saturation=0.95,ax=ax[0])\n",
+    "sns.countplot(x=df['parental_level_of_education'],data=df,palette = 'bright',hue='test_preparation_course',saturation=0.95,ax=ax[0])\n",
     "ax[0].set_title('Students vs test preparation course ',color='black',size=25)\n",
     "for container in ax[0].containers:\n",
     "    ax[0].bar_label(container,color='black',size=20)\n",
     "    \n",
-    "sns.countplot(x=df['parental level of education'],data=df,palette = 'bright',hue='lunch',saturation=0.95,ax=ax[1])\n",
+    "sns.countplot(x=df['parental_level_of_education'],data=df,palette = 'bright',hue='lunch',saturation=0.95,ax=ax[1])\n",
+    "ax[1].set_title('Students vs Lunch Type', color='black', size=25)\n",
     "for container in ax[1].containers:\n",
     "    ax[1].bar_label(container,color='black',size=20)   "
    ]
@@ -1728,11 +1731,11 @@
    "source": [
     "plt.figure(figsize=(12,6))\n",
     "plt.subplot(2,2,1)\n",
-    "sns.barplot (x=df['lunch'], y=df['math score'], hue=df['test preparation course'])\n",
+    "sns.barplot (x=df['lunch'], y=df['math_score'], hue=df['test_preparation_course'])\n",
     "plt.subplot(2,2,2)\n",
-    "sns.barplot (x=df['lunch'], y=df['reading score'], hue=df['test preparation course'])\n",
+    "sns.barplot (x=df['lunch'], y=df['reading_score'], hue=df['test_preparation_course'])\n",
     "plt.subplot(2,2,3)\n",
-    "sns.barplot (x=df['lunch'], y=df['writing score'], hue=df['test preparation course'])"
+    "sns.barplot (x=df['lunch'], y=df['writing_score'], hue=df['test_preparation_course'])"
    ]
   },
   {
@@ -1761,11 +1764,11 @@
    "source": [
     "plt.subplots(1,4,figsize=(16,5))\n",
     "plt.subplot(141)\n",
-    "sns.boxplot(df['math score'],color='skyblue')\n",
+    "sns.boxplot(df['math_score'],color='skyblue')\n",
     "plt.subplot(142)\n",
-    "sns.boxplot(df['reading score'],color='hotpink')\n",
+    "sns.boxplot(df['reading_score'],color='hotpink')\n",
     "plt.subplot(143)\n",
-    "sns.boxplot(df['writing score'],color='yellow')\n",
+    "sns.boxplot(df['writing_score'],color='yellow')\n",
     "plt.subplot(144)\n",
     "sns.boxplot(df['average'],color='lightgreen')\n",
     "plt.show()"


### PR DESCRIPTION
This pull request addresses column name inconsistencies in the notebook. The following column names have been updated for consistency:

- **math score** to **math_score**
- **reading score** to **reading_score**
- **writing score** to **writing_score**
- **parental level of education** to **parental_level_of_education**
- **race/ethnicity** to **race_ethnicity**
- **test preparation course** to **test_preparation_course**
