### PR TITLE
Fixed Typo in data_transformation.py

### DIFF
--- a/src/components/data_transformation.py
+++ b/src/components/data_transformation.py
@@ -16,7 +16,7 @@ from src.utils import save_object
 
 @dataclass
 class DataTransformationConfig:
-    preprocessor_obj_file_path=os.path.join('artifacts',"proprocessor.pkl")
+    preprocessor_obj_file_path=os.path.join('artifacts',"preprocessor.pkl")
 
 class DataTransformation:
     def __init__(self):


### PR DESCRIPTION
The typo in the PKL file creates a file with incorrect name at the location which the app is not able to find and the prediction pipeline gives Internal Server Error after submitting the inputs